### PR TITLE
Do not publish `flow-typed` directory to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 src
 __tests__
+flow-typed


### PR DESCRIPTION
After installing `snapshot-diff` webstorm gone crazy and things that jest functions belongs to `snapshot-diff` 
<img width="405" alt="screen shot 2017-08-09 at 18 30 42" src="https://user-images.githubusercontent.com/4734297/29127961-921bf7e8-7d33-11e7-95c4-532b65dfe6e4.png">

