### PR TITLE
fix small issues in typescript types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -13,7 +13,7 @@ declare namespace jest {
 }
 
 declare module 'snapshot-diff' {
-    function diff(a: object, b: object): string;
-    namespace diff {}
-    export = diff;
+  function diff(a: object, b: object): string;
+  namespace diff {}
+  export = diff;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,13 @@ type DiffOptions = {
 };
 
 declare namespace jest {
-  interface Matchers {
-    toMatchDiffSnapshot(valueB: any, options?: DiffOptions): boolean
+  interface Matchers<R> {
+    toMatchDiffSnapshot(valueB: any, options?: DiffOptions): R
   }
+}
+
+declare module 'snapshot-diff' {
+    function diff(a: object, b: object): string;
+    namespace diff {}
+    export = diff;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,7 +13,7 @@ declare namespace jest {
 }
 
 declare module 'snapshot-diff' {
-  function diff(a: object, b: object): string;
+  function diff(a: any, b: any): string;
   namespace diff {}
   export = diff;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,7 +13,7 @@ declare namespace jest {
 }
 
 declare module 'snapshot-diff' {
-  function diff(a: any, b: any): string;
+  function diff(a: any, b: any, options?: DiffOptions): string;
   namespace diff {}
   export = diff;
 }


### PR DESCRIPTION
This PR simply adds the required generic to the `Matcher` definition and also declares that this repo is a module.

(the module type definition might not be completely accurate. If not, let me know and I'll fix).

Without these changes, typescript will complain and likely error (depending on your configuration).